### PR TITLE
DataIoIterator now returns channel names, positions and adjacency matrix

### DIFF
--- a/benchmarks/MOABB/extra-requirements.txt
+++ b/benchmarks/MOABB/extra-requirements.txt
@@ -1,4 +1,4 @@
-mne
+mne==1.6.1
 moabb
 orion
 orion[profet]

--- a/benchmarks/MOABB/utils/dataio_iterators.py
+++ b/benchmarks/MOABB/utils/dataio_iterators.py
@@ -178,7 +178,7 @@ class BaseDataIOIterator(abc.ABC):
         n_steps_channel_selection: Optional[int] = None,
         events_to_load: Optional[List[str]] = None,
         save_prepared_dataset: bool = True,
-    ) -> tuple[str, dict[str, _SplitDataloaders]]:
+    ) -> Tuple[str, _SplitDataloaders]:
         """This function returns the pre-processed datasets (training, validation and test sets).
 
         Arguments

--- a/benchmarks/MOABB/utils/dataio_iterators.py
+++ b/benchmarks/MOABB/utils/dataio_iterators.py
@@ -6,9 +6,10 @@ Different training strategies have been implemented as distinct data iterators, 
 - Leave-One-Session-Out
 - Leave-One-Subject-Out
 
-Author
+Authors
 ------
 Davide Borra, 2021
+Drew Wagner, 2024
 """
 
 import abc

--- a/benchmarks/MOABB/utils/dataio_iterators.py
+++ b/benchmarks/MOABB/utils/dataio_iterators.py
@@ -128,7 +128,14 @@ def sample_channels(x, adjacency_mtx, ch_names, n_steps, seed_nodes=["Cz"]):
     return x
 
 
-class LeaveOneSessionOut(object):
+class BaseDataIOIterator:
+    
+    def __init__(self, tag, seed):
+        self.iterator_tag = tag
+        np.random.seed(seed)
+
+
+class LeaveOneSessionOut(BaseDataIOIterator):
     """Leave one session out iterator for MOABB datasets.
     Designing within-subject, cross-session and session-agnostic iterations on the dataset for a specific paradigm.
     For each subject, one session is held back as test set and the remaining ones are used to train neural networks.
@@ -142,8 +149,7 @@ class LeaveOneSessionOut(object):
     """
 
     def __init__(self, seed):
-        self.iterator_tag = "leave-one-session-out"
-        np.random.seed(seed)
+        super().__init__("leave-one-session-out", seed)
 
     def prepare(
         self,
@@ -347,7 +353,7 @@ class LeaveOneSessionOut(object):
         return tail_path, datasets
 
 
-class LeaveOneSubjectOut(object):
+class LeaveOneSubjectOut(BaseDataIOIterator):
     """Leave one subject out iterator for MOABB datasets.
     Designing cross-subject, cross-session and subject-agnostic iterations on the dataset for a specific paradigm.
     One subject is held back as test set and the remaining ones are used to train neural networks.
@@ -361,8 +367,7 @@ class LeaveOneSubjectOut(object):
     """
 
     def __init__(self, seed):
-        self.iterator_tag = "leave-one-subject-out"
-        np.random.seed(seed)
+        super().__init__("leave-one-subject-out", seed)
 
     def prepare(
         self,

--- a/benchmarks/MOABB/utils/dataio_iterators.py
+++ b/benchmarks/MOABB/utils/dataio_iterators.py
@@ -11,10 +11,16 @@ Author
 Davide Borra, 2021
 """
 
-import numpy as np
-import torch
-from torch.utils.data import TensorDataset, DataLoader
+import abc
 import os
+from collections import namedtuple
+from typing import List, Optional, Tuple, TypedDict
+
+import numpy as np
+import pandas as pd
+import torch
+from moabb.datasets.base import BaseDataset as MOABBDataset
+from torch.utils.data import DataLoader, TensorDataset
 from utils.prepare import prepare_data
 
 
@@ -128,11 +134,229 @@ def sample_channels(x, adjacency_mtx, ch_names, n_steps, seed_nodes=["Cz"]):
     return x
 
 
-class BaseDataIOIterator:
-    
+class _SplitDataloaders(TypedDict):
+    train: DataLoader
+    valid: DataLoader
+    test: DataLoader
+
+
+XYSplits = namedtuple(
+    "XYSplits", ["x_train", "y_train", "x_valid", "y_valid", "x_test", "y_test"]
+)
+
+
+class _DataDict(TypedDict):
+    srate: int
+    original_interval: Tuple[float, float]
+    adjacency_mtx: np.ndarray
+    channels: List[str]
+    subject: str
+
+
+class BaseDataIOIterator(abc.ABC):
     def __init__(self, tag, seed):
         self.iterator_tag = tag
         np.random.seed(seed)
+
+    def prepare(
+        self,
+        *,
+        data_folder: str,
+        cached_data_folder: str,
+        dataset: MOABBDataset,
+        batch_size: int,
+        valid_ratio: float,
+        original_sample_rate: int,
+        target_subject_idx: int,
+        target_session_idx: Optional[int] = None,
+        sample_rate: Optional[int] = None,
+        fmin: Optional[float] = None,
+        fmax: Optional[float] = None,
+        tmin: Optional[float] = None,
+        tmax: Optional[float] = None,
+        n_steps_channel_selection: Optional[int] = None,
+        events_to_load: Optional[List[str]] = None,
+        save_prepared_dataset: bool = True,
+    ) -> tuple[str, dict[str, _SplitDataloaders]]:
+        """This function returns the pre-processed datasets (training, validation and test sets).
+
+        Arguments
+        ---------
+        data_folder: str
+            String containing the path where data were downloaded.
+        cached_data_folder: str
+            String containing the path where data will be cached (into .pkl files) during preparation.
+            This is convenient to speed up overall training when performing multiple trainings on EEG signals
+            pre-processed always in the same way.
+        dataset: moabb.datasets.?
+            MOABB dataset.
+        batch_size: int
+            Mini-batch size.
+        valid_ratio: float
+            Ratio for extracting the validation set from the available training set (between 0 and 1).
+        original_sample_rate: int
+            Sampling rate of the loaded dataset (Hz).
+        target_subject_idx: int
+            Index of the subject to use to train the network.
+        target_session_idx: int
+            Index of the session to use to train the network.
+        sample_rate: int
+            Target sampling rate (Hz).
+        fmin: float
+            Low cut-off frequency of the applied band-pass filtering (Hz).
+        fmax: float
+            High cut-off frequency of the applied band-pass filtering (Hz).
+        tmin: float
+            Start time of the EEG epoch, with respect to the event as defined in the dataset (s).
+            See MOABB documentation and reference publications of each dataset for additional details about datasets.
+        tmax: float
+            Stop time of the EEG epoch, with respect to the event as defined in the dataset (s).
+            See MOABB documentation and reference publications of each dataset for additional details about datasets.
+        n_steps_channel_selection: int
+            Number of steps to perform when sampling a subset of channels from a seed channel, based on the adjacency matrix.
+        events_to_load: list
+            List of 'events' considered when loading the MOABB dataset.
+            It serves to load specific conditions (e.g., ["right_hand", "left_hand"] for specific movement conditions).
+            See MOABB documentation and reference publications of each dataset for additional details about datasets.
+
+        save_prepared_dataset: bool
+            Flag to save the prepared dataset into a pkl file.
+        ...
+
+        Returns
+        ---------
+        tail_path: str
+            String containing the relative path where results will be stored for the specified iterator, subject and session.
+        datasets: dict
+            Dictionary containing all sets as dataloaders (keys: 'train', 'test', 'valid').
+        ---------
+        """
+        interval = [tmin, tmax]
+        subject = dataset.subject_list[target_subject_idx]
+
+        self.validate_dataset_or_raise(dataset)
+
+        (
+            target_data_dict,
+            (x_train, y_train, x_valid, y_valid, x_test, y_test),
+        ) = self.get_data(
+            target_subject_idx=target_subject_idx,
+            target_session_idx=target_session_idx,
+            valid_ratio=valid_ratio,
+            dataset=dataset,
+            data_folder=data_folder,
+            cached_data_folder=cached_data_folder,
+            original_sample_rate=original_sample_rate,
+            sample_rate=sample_rate,
+            fmin=fmin,
+            fmax=fmax,
+            events_to_load=events_to_load,
+            save_prepared_dataset=save_prepared_dataset,
+        )
+
+        # time cropping
+        if interval != target_data_dict["original_interval"]:
+            x_train = crop_signals(
+                x=x_train,
+                srate=target_data_dict["srate"],
+                interval_in=target_data_dict["original_interval"],
+                interval_out=interval,
+            )
+            x_valid = crop_signals(
+                x=x_valid,
+                srate=target_data_dict["srate"],
+                interval_in=target_data_dict["original_interval"],
+                interval_out=interval,
+            )
+            x_test = crop_signals(
+                x=x_test,
+                srate=target_data_dict["srate"],
+                interval_in=target_data_dict["original_interval"],
+                interval_out=interval,
+            )
+
+        # channel sampling
+        if n_steps_channel_selection is not None:
+            x_train = sample_channels(
+                x_train,
+                target_data_dict["adjacency_mtx"],
+                target_data_dict["channels"],
+                n_steps=n_steps_channel_selection,
+            )
+            x_valid = sample_channels(
+                x_valid,
+                target_data_dict["adjacency_mtx"],
+                target_data_dict["channels"],
+                n_steps=n_steps_channel_selection,
+            )
+            x_test = sample_channels(
+                x_test,
+                target_data_dict["adjacency_mtx"],
+                target_data_dict["channels"],
+                n_steps=n_steps_channel_selection,
+            )
+
+        # swap axes: from (N_examples, C, T) to (N_examples, T, C)
+        x_train = np.swapaxes(x_train, -1, -2)
+        x_valid = np.swapaxes(x_valid, -1, -2)
+        x_test = np.swapaxes(x_test, -1, -2)
+
+        # dataloaders
+        train_loader, valid_loader, test_loader = get_dataloader(
+            batch_size, (x_train, y_train), (x_valid, y_valid), (x_test, y_test)
+        )
+        datasets = {}
+        datasets["train"] = train_loader
+        datasets["valid"] = valid_loader
+        datasets["test"] = test_loader
+
+        tail_path = self.get_tail_path(subject, target_data_dict["session"])
+        return tail_path, datasets
+
+    def validate_dataset_or_raise(self, dataset: MOABBDataset) -> None:
+        """Check that the dataset is compatible, or raise an error."""
+        pass
+
+    @abc.abstractmethod
+    def get_data(
+        self,
+        target_subject_idx: int,
+        target_session_idx: Optional[int],
+        valid_ratio: float,
+        dataset: MOABBDataset,
+        data_folder: Optional[str],
+        cached_data_folder: Optional[str],
+        original_sample_rate: int,
+        sample_rate: Optional[int],
+        fmin: Optional[float],
+        fmax: Optional[float],
+        events_to_load: Optional[List[str]],
+        save_prepared_dataset: bool,
+    ) -> tuple[_DataDict, XYSplits]:
+        """Prepare the numpy data as train, valid and test splits.
+
+        Arguments
+        =========
+        See `prepare` method.
+
+        Returns
+        =======
+        target_data_dict: _DataDict
+            The metadata relating to the target, including session name and
+            adjacency matrix.
+        (x_train, y_train, x_valid, y_valid, x_test, y_test): np.ndarray
+            The numpy arrays corresponding to each data split.
+        """
+
+    def get_tail_path(self, subject: int, session: Optional[str]) -> str:
+        """Returns the tail path for the directory."""
+
+        tail_path = os.path.join(
+            self.iterator_tag, "sub-{0}".format(str(subject).zfill(3)),
+        )
+        if session is not None:
+            tail_path = os.path.join(tail_path, session)
+        return tail_path
 
 
 class LeaveOneSessionOut(BaseDataIOIterator):
@@ -151,104 +375,23 @@ class LeaveOneSessionOut(BaseDataIOIterator):
     def __init__(self, seed):
         super().__init__("leave-one-session-out", seed)
 
-    def prepare(
+    def get_data(
         self,
-        data_folder=None,
-        cached_data_folder=None,
-        dataset=None,
-        batch_size=None,
-        valid_ratio=None,
-        target_subject_idx=None,
-        target_session_idx=None,
-        events_to_load=None,
-        original_sample_rate=None,
-        sample_rate=None,
-        fmin=None,
-        fmax=None,
-        tmin=None,
-        tmax=None,
-        save_prepared_dataset=None,
-        n_steps_channel_selection=None,
-    ):
-        """This function returns the pre-processed datasets (training, validation and test sets).
-
-        Arguments
-        ---------
-        data_folder: str
-            String containing the path where data were downloaded.
-        cached_data_folder: str
-            String containing the path where data will be cached (into .pkl files) during preparation.
-            This is convenient to speed up overall training when performing multiple trainings on EEG signals
-            pre-processed always in the same way.
-        dataset: moabb.datasets.?
-            MOABB dataset.
-        batch_size: int
-            Mini-batch size.
-        valid_ratio: float
-            Ratio for extracting the validation set from the available training set (between 0 and 1).
-        target_subject_idx: int
-            Index of the subject to use to train the network.
-        target_session_idx: int
-            Index of the session to use to train the network.
-        events_to_load: list
-            List of 'events' considered when loading the MOABB dataset.
-            It serves to load specific conditions (e.g., ["right_hand", "left_hand"] for specific movement conditions).
-            See MOABB documentation and reference publications of each dataset for additional details about datasets.
-        original_sample_rate: int
-            Sampling rate of the loaded dataset (Hz).
-        sample_rate: int
-            Target sampling rate (Hz).
-        fmin: float
-            Low cut-off frequency of the applied band-pass filtering (Hz).
-        fmax: float
-            High cut-off frequency of the applied band-pass filtering (Hz).
-        tmin: float
-            Start time of the EEG epoch, with respect to the event as defined in the dataset (s).
-            See MOABB documentation and reference publications of each dataset for additional details about datasets.
-        tmax: float
-            Stop time of the EEG epoch, with respect to the event as defined in the dataset (s).
-            See MOABB documentation and reference publications of each dataset for additional details about datasets.
-        save_prepared_dataset: bool
-            Flag to save the prepared dataset into a pkl file.
-        n_steps_channel_selection: int
-            Number of steps to perform when sampling a subset of channels from a seed channel, based on the adjacency matrix.
-        ...
-
-        Returns
-        ---------
-        tail_path: str
-            String containing the relative path where results will be stored for the specified iterator, subject and session.
-        datasets: dict
-            Dictionary containing all sets (keys: 'train', 'test', 'valid').
-         ---------
-        """
-        interval = [tmin, tmax]
-
+        target_subject_idx,
+        target_session_idx,
+        valid_ratio,
+        **prepare_data_kwargs,
+    ) -> Tuple[dict, XYSplits]:
         # preparing or loading dataset
         data_dict = prepare_data(
-            data_folder=data_folder,
-            cached_data_folder=cached_data_folder,
-            dataset=dataset,
-            events_to_load=events_to_load,
-            srate_in=original_sample_rate,
-            srate_out=sample_rate,
-            fmin=fmin,
-            fmax=fmax,
-            idx_subject_to_prepare=target_subject_idx,
-            save_prepared_dataset=save_prepared_dataset,
+            idx_subject_to_prepare=target_subject_idx, **prepare_data_kwargs,
         )
 
         x = data_dict["x"]
         y = data_dict["y"]
-        srate = data_dict["srate"]
-        original_interval = data_dict["interval"]
         metadata = data_dict["metadata"]
-        if np.unique(metadata.session).shape[0] < 2:
-            raise (
-                ValueError(
-                    "The number of sessions in the dataset must be >= 2 for leave-one-session-out iterations"
-                )
-            )
+
+        self._validate_metadata_or_raise(metadata)
         sessions = np.unique(metadata.session)
         sess_id_test = [sessions[target_session_idx]]
         sess_id_train = np.setdiff1d(sessions, sess_id_test)
@@ -288,69 +431,18 @@ class LeaveOneSessionOut(BaseDataIOIterator):
         x_test = x[idx_test, ...]
         y_test = y[idx_test]
 
-        # time cropping
-        if interval != original_interval:
-            x_train = crop_signals(
-                x=x_train,
-                srate=srate,
-                interval_in=original_interval,
-                interval_out=interval,
-            )
-            x_valid = crop_signals(
-                x=x_valid,
-                srate=srate,
-                interval_in=original_interval,
-                interval_out=interval,
-            )
-            x_test = crop_signals(
-                x=x_test,
-                srate=srate,
-                interval_in=original_interval,
-                interval_out=interval,
-            )
-
-        # channel sampling
-        if n_steps_channel_selection is not None:
-            x_train = sample_channels(
-                x_train,
-                data_dict["adjacency_mtx"],
-                data_dict["channels"],
-                n_steps=n_steps_channel_selection,
-            )
-            x_valid = sample_channels(
-                x_valid,
-                data_dict["adjacency_mtx"],
-                data_dict["channels"],
-                n_steps=n_steps_channel_selection,
-            )
-            x_test = sample_channels(
-                x_test,
-                data_dict["adjacency_mtx"],
-                data_dict["channels"],
-                n_steps=n_steps_channel_selection,
-            )
-
-        # swap axes: from (N_examples, C, T) to (N_examples, T, C)
-        x_train = np.swapaxes(x_train, -1, -2)
-        x_valid = np.swapaxes(x_valid, -1, -2)
-        x_test = np.swapaxes(x_test, -1, -2)
-
-        # dataloaders
-        train_loader, valid_loader, test_loader = get_dataloader(
-            batch_size, (x_train, y_train), (x_valid, y_valid), (x_test, y_test)
+        return (
+            data_dict,
+            XYSplits(x_train, y_train, x_valid, y_valid, x_test, y_test),
         )
-        datasets = {}
-        datasets["train"] = train_loader
-        datasets["valid"] = valid_loader
-        datasets["test"] = test_loader
-        tail_path = os.path.join(
-            self.iterator_tag,
-            "sub-{0}".format(
-                str(dataset.subject_list[target_subject_idx]).zfill(3)
-            ),
-            sessions[target_session_idx],
-        )
-        return tail_path, datasets
+
+    def _validate_metadata_or_raise(self, metadata: pd.DataFrame):
+        if np.unique(metadata.session).shape[0] < 2:
+            raise (
+                ValueError(
+                    "The number of sessions in the dataset must be >= 2 for leave-one-session-out iterations"
+                )
+            )
 
 
 class LeaveOneSubjectOut(BaseDataIOIterator):
@@ -369,105 +461,24 @@ class LeaveOneSubjectOut(BaseDataIOIterator):
     def __init__(self, seed):
         super().__init__("leave-one-subject-out", seed)
 
-    def prepare(
+    def get_data(
         self,
-        data_folder=None,
-        cached_data_folder=None,
-        dataset=None,
-        batch_size=None,
-        valid_ratio=None,
+        *,
+        dataset: MOABBDataset,
         target_subject_idx=None,
-        target_session_idx=None,
-        events_to_load=None,
-        original_sample_rate=None,
-        sample_rate=None,
-        fmin=None,
-        fmax=None,
-        tmin=None,
-        tmax=None,
-        save_prepared_dataset=None,
-        n_steps_channel_selection=None,
+        target_session_idx=None,  # noqa
+        valid_ratio=None,
+        **prepare_data_kwargs,
     ):
-        """This function returns the pre-processed datasets (training, validation and test sets).
-
-        Arguments
-        ---------
-        data_folder: str
-            String containing the path where data were downloaded.
-        cached_data_folder: str
-            String containing the path where data will be cached (into .pkl files) during preparation.
-            This is convenient to speed up overall training when performing multiple trainings on EEG signals
-            pre-processed always in the same way.
-        dataset: moabb.datasets.?
-            MOABB dataset.
-        batch_size: int
-            Mini-batch size.
-        valid_ratio: float
-            Ratio for extracting the validation set from the available training set (between 0 and 1).
-        target_subject_idx: int
-            Index of the subject to use to train the network.
-        target_session_idx: int
-            Index of the session to use to train the network.
-            For leave-one-subject-out this parameter is ininfluent (it is not used).
-            It was held for symmetry with leave-one-session-out iterator and for convenience with the rest of the code.
-        events_to_load: list
-            List of 'events' considered when loading the MOABB dataset.
-            It serves to load specific conditions (e.g., ["right_hand", "left_hand"] for specific movement conditions).
-            See MOABB documentation and reference publications of each dataset for additional details about datasets.
-        original_sample_rate: int
-            Sampling rate of the loaded dataset (Hz).
-        sample_rate: int
-            Target sampling rate (Hz).
-        fmin: float
-            Low cut-off frequency of the applied band-pass filtering (Hz).
-        fmax: float
-            High cut-off frequency of the applied band-pass filtering (Hz).
-        tmin: float
-            Start time of the EEG epoch, with respect to the event as defined in the dataset (s).
-            See MOABB documentation and reference publications of each dataset for additional details about datasets.
-        tmax: float
-            Stop time of the EEG epoch, with respect to the event as defined in the dataset (s).
-            See MOABB documentation and reference publications of each dataset for additional details about datasets.
-        save_prepared_dataset: bool
-            Flag to save the prepared dataset into a pkl file.
-        n_steps_channel_selection: int
-            Number of steps to perform when sampling a subset of channels from a seed channel, based on the adjacency matrix.
-        ...
-
-        Returns
-        ---------
-        tail_path: str
-            String containing the relative path where results will be stored for the specified iterator, subject and session.
-        datasets: dict
-            Dictionary containing all sets (keys: 'train', 'test', 'valid').
-         ---------
-        """
-        interval = [tmin, tmax]
-        if len(dataset.subject_list) < 2:
-            raise (
-                ValueError(
-                    "The number of subjects in the dataset must be >= 2 for leave-one-subject-out iterations"
-                )
-            )
-
         # preparing or loading test set
-        data_dict = prepare_data(
-            data_folder=data_folder,
-            cached_data_folder=cached_data_folder,
+        target_data_dict = prepare_data(
             dataset=dataset,
-            events_to_load=events_to_load,
-            srate_in=original_sample_rate,
-            srate_out=sample_rate,
-            fmin=fmin,
-            fmax=fmax,
             idx_subject_to_prepare=target_subject_idx,
-            save_prepared_dataset=save_prepared_dataset,
+            **prepare_data_kwargs,
         )
 
-        x_test = data_dict["x"]
-        y_test = data_dict["y"]
-        original_interval = data_dict["interval"]
-        srate = data_dict["srate"]
+        x_test = target_data_dict["x"]
+        y_test = target_data_dict["y"]
 
         subject_idx_train = [
             i
@@ -493,16 +504,9 @@ class LeaveOneSubjectOut(BaseDataIOIterator):
         for subject_idx in subject_idx_train:
             # preparing or loading training/valid set
             data_dict = prepare_data(
-                data_folder=data_folder,
-                cached_data_folder=cached_data_folder,
                 dataset=dataset,
-                events_to_load=events_to_load,
-                srate_in=original_sample_rate,
-                srate_out=sample_rate,
-                fmin=fmin,
-                fmax=fmax,
                 idx_subject_to_prepare=subject_idx,
-                save_prepared_dataset=save_prepared_dataset,
+                **prepare_data_kwargs,
             )
 
             tmp_x_train = data_dict["x"]
@@ -534,70 +538,21 @@ class LeaveOneSubjectOut(BaseDataIOIterator):
             y_train.extend(tmp_y_train)
             x_valid.extend(tmp_x_valid)
             y_valid.extend(tmp_y_valid)
+
         x_train = np.array(x_train)
         y_train = np.array(y_train)
         x_valid = np.array(x_valid)
         y_valid = np.array(y_valid)
 
-        # time cropping
-        if interval != original_interval:
-            x_train = crop_signals(
-                x=x_train,
-                srate=srate,
-                interval_in=original_interval,
-                interval_out=interval,
-            )
-            x_valid = crop_signals(
-                x=x_valid,
-                srate=srate,
-                interval_in=original_interval,
-                interval_out=interval,
-            )
-            x_test = crop_signals(
-                x=x_test,
-                srate=srate,
-                interval_in=original_interval,
-                interval_out=interval,
-            )
-
-        # channel sampling
-        if n_steps_channel_selection is not None:
-            x_train = sample_channels(
-                x_train,
-                data_dict["adjacency_mtx"],
-                data_dict["channels"],
-                n_steps=n_steps_channel_selection,
-            )
-            x_valid = sample_channels(
-                x_valid,
-                data_dict["adjacency_mtx"],
-                data_dict["channels"],
-                n_steps=n_steps_channel_selection,
-            )
-            x_test = sample_channels(
-                x_test,
-                data_dict["adjacency_mtx"],
-                data_dict["channels"],
-                n_steps=n_steps_channel_selection,
-            )
-
-        # swap axes: from (N_examples, C, T) to (N_examples, T, C)
-        x_train = np.swapaxes(x_train, -1, -2)
-        x_valid = np.swapaxes(x_valid, -1, -2)
-        x_test = np.swapaxes(x_test, -1, -2)
-
-        # dataloaders
-        train_loader, valid_loader, test_loader = get_dataloader(
-            batch_size, (x_train, y_train), (x_valid, y_valid), (x_test, y_test)
+        return (
+            target_data_dict,
+            (x_train, y_train, x_valid, y_valid, x_test, y_test,),
         )
-        datasets = {}
-        datasets["train"] = train_loader
-        datasets["valid"] = valid_loader
-        datasets["test"] = test_loader
-        tail_path = os.path.join(
-            self.iterator_tag,
-            "sub-{0}".format(
-                str(dataset.subject_list[target_subject_idx]).zfill(3)
-            ),
-        )
-        return tail_path, datasets
+
+    def validate_dataset_or_raise(self, dataset: MOABBDataset):
+        if len(dataset.subject_list) < 2:
+            raise (
+                ValueError(
+                    "The number of subjects in the dataset must be >= 2 for leave-one-subject-out iterations"
+                )
+            )

--- a/benchmarks/MOABB/utils/prepare.py
+++ b/benchmarks/MOABB/utils/prepare.py
@@ -78,9 +78,16 @@ def get_output_dict(
             resample=srate_out,  # downsample
         )
 
-    x, y, labels, metadata, channels, adjacency_mtx, srate = load_data(
-        paradigm, dataset, [subject]
-    )
+    (
+        x,
+        y,
+        labels,
+        metadata,
+        channels,
+        adjacency_mtx,
+        ch_positions,
+        srate,
+    ) = load_data(paradigm, dataset, [subject])
 
     if verbose == 1:
         for l in np.unique(labels):
@@ -106,6 +113,7 @@ def get_output_dict(
 
     output_dict["channels"] = channels
     output_dict["adjacency_mtx"] = adjacency_mtx
+    output_dict["ch_positions"] = ch_positions
     output_dict["x"] = x
     output_dict["y"] = y
     output_dict["labels"] = labels
@@ -122,6 +130,7 @@ def load_data(paradigm, dataset, idx):
     In addition metadata, channel names and the sampling rate are provided too."""
     x, labels, metadata = paradigm.get_data(dataset, idx, True)
     ch_names = x.info.ch_names
+    ch_positions = x.info.get_montage().get_positions()["ch_pos"]
     adjacency, _ = find_ch_adjacency(x.info, ch_type="eeg")
     adjacency_mtx = scipy.sparse.csr_matrix.toarray(
         adjacency
@@ -132,7 +141,7 @@ def load_data(paradigm, dataset, idx):
     y = [dataset.event_id[yy] for yy in labels]
     y = np.array(y)
     y -= y.min()
-    return x, y, labels, metadata, ch_names, adjacency_mtx, srate
+    return x, y, labels, metadata, ch_names, adjacency_mtx, ch_positions, srate
 
 
 def download_data(data_folder, dataset):

--- a/benchmarks/MP3S/SLURP/LSTM_linear/prepare.py
+++ b/benchmarks/MP3S/SLURP/LSTM_linear/prepare.py
@@ -56,7 +56,7 @@ def prepare_SLURP(
             shutil.unpack_archive(zip_location, data_folder)
 
     splits = [
-        "train_real",
+        "train",
         "train_synthetic",
         "devel",
         "test",


### PR DESCRIPTION
- Refactored dataio_iterator classes (LeaveOneSessionOut, LeaveOneSubjectOut) to inherit from a common BaseDataIOIterator, which makes it easier to maintain and extend the behaviour.
- Adjusted the  base implementation to also return:
    - Channel names
    - 3D channel positions
    - Adjacency matrix (which is usually estimated from the channel positions using Delauney triangulation)
 
 The new return from `.prepare(...)` looks like, for example:
 ```
 {'train': <torch.utils.data.dataloader.DataLoader at 0x7fa8417ba5f0>,
 'valid': <torch.utils.data.dataloader.DataLoader at 0x7fa8417b8910>,
 'test': <torch.utils.data.dataloader.DataLoader at 0x7fa84199c460>,
 'ch_names': ['FC1', 'FCz', 'FC2', 'C1', 'Cz', 'C2', 'CPz'],
 'channel_positions': array([[-0.03571586,  0.06171406,  0.11798302],
        [-0.00127143,  0.06345979,  0.12657198],
        [ 0.03313098,  0.06182849,  0.1167817 ],
        [-0.03793782,  0.02633745,  0.12977061],
        [-0.00137413,  0.02761709,  0.14019949],
        [ 0.03589272,  0.02635814,  0.12841234],
        [-0.0015249 , -0.01051838,  0.14154914]]),
 'adjacency_mtx': array([[1, 1, 0, 1, 1, 0, 0],
        [1, 1, 1, 0, 1, 0, 0],
        [0, 1, 1, 0, 1, 1, 0],
        [1, 0, 0, 1, 1, 0, 1],
        [1, 1, 1, 1, 1, 1, 1],
        [0, 0, 1, 0, 1, 1, 1],
        [0, 0, 0, 1, 1, 1, 1]])}
 ```